### PR TITLE
fix: PR Documentation GeneratorのOAuth認証設定を修正

### DIFF
--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -29,9 +29,13 @@ jobs:
         run: mkdir -p docs/pull-requests
       
       - name: Generate PR Documentation
-        uses: anthropics/claude-code-action@beta
+        uses: Akira-Papa/claude-code-action@main
         with:
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
+          use_oauth: true
+          claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
+          claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
+          claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
           timeout_minutes: 30
           direct_prompt: |
             Generate comprehensive documentation for the merged PR #${{ github.event.pull_request.number }}.


### PR DESCRIPTION
## 概要
PR Documentation GeneratorでOAuth認証を使用するように修正しました。

## 変更内容
- アクションを`Akira-Papa/claude-code-action@main`に変更
- OAuth認証を有効化（`use_oauth: true`）
- 必要なsecretsを追加:
  - `CLAUDE_ACCESS_TOKEN`
  - `CLAUDE_REFRESH_TOKEN`
  - `CLAUDE_EXPIRES_AT`

## テスト計画
PRがマージされた際にPR Documentation Generatorが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)